### PR TITLE
Run `ctest` in serial to avoid segfault/race condition

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -12,19 +12,11 @@ cxx_compiler_version:
 - '9'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
-openssl:
-- 1.1.1
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  openssl:
-    max_pin: x.x.x
-  zlib:
-    max_pin: x.x
 target_platform:
 - linux-64
 zip_keys:
 - - cdt_name
   - docker_image
-zlib:
-- '1.2'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -12,16 +12,8 @@ cxx_compiler_version:
 - '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
-openssl:
-- 1.1.1
 pin_run_as_build:
   boost-cpp:
     max_pin: x.x.x
-  openssl:
-    max_pin: x.x.x
-  zlib:
-    max_pin: x.x
 target_platform:
 - osx-64
-zlib:
-- '1.2'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -19,7 +19,7 @@ cmake \
 cmake --build . --parallel ${CPU_COUNT} --verbose
 
 # test
-ctest --parallel ${CPU_COUNT} --verbose
+ctest --verbose
 
 # install
 cmake --build . --parallel ${CPU_COUNT} --verbose --target install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage("ldas-tools-ldasgen", max_pin="x.x") }}


### PR DESCRIPTION
This PR updates the `ctest` call in `build.sh` to run the tests without the `--parallel` option, to avoid an apparent race condition that leads to a segfault.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
